### PR TITLE
Change testbox.md with working sample

### DIFF
--- a/packages/boxjson/testbox.md
+++ b/packages/boxjson/testbox.md
@@ -29,8 +29,10 @@ testbox run
 
 ```javascript
 "testbox" : {
-    { "cf11"   : "http://cf9.localhost/tests/runner.cfm" },
-    { "lucee" : "http://railo.localhost/tests/runner.cfm" }
+    "runner" : [
+        { "cf11"   : "http://cf9.localhost/tests/runner.cfm" },
+        { "lucee" : "http://railo.localhost/tests/runner.cfm" }
+    ]
 }
 ```
 


### PR DESCRIPTION
Change "`testbox.runner` can alternatively be an array of objects containing "named" runner URLs." example to a more accurate and working sample.