### PR TITLE
Fixes minor markdown typo

### DIFF
--- a/embedded_server/url_rewrites.md
+++ b/embedded_server/url_rewrites.md
@@ -78,6 +78,7 @@ You can place your custom rewrite rule wherever you like, and refer to it by usi
 ```bash
 server set web.rewrites.enable=true
 server set web.rewrites.config=/my/custom/path/customRewrites.xml
+```
 
 or
 


### PR DESCRIPTION
There was some a missing backticks that prevented the new examples from formatting correctly.