### PR TITLE
Update custom_error_pages.md

### DIFF
--- a/embedded_server/custom_error_pages.md
+++ b/embedded_server/custom_error_pages.md
@@ -19,7 +19,7 @@ This is what you `server.json` might look like:
 
 You can set error pages via the `server set` command like this:
 ```
-server set web.aliases.404=/missing.htm
+server set web.errorPages.404=/missing.htm
 ```
 
 ## Accessing error variables


### PR DESCRIPTION
Just a little change on the key for setting the error pages currently it points to "aliases" and should be "errorPages":  `server set web.errorPages.404=/missing.htm`