### PR TITLE
Updated recipes.md to explain comment prefixing

### DIFF
--- a/usage/execution/recipes.md
+++ b/usage/execution/recipes.md
@@ -8,7 +8,7 @@ Read more about the **recipe** command in our [Command API docs](http://apidocs.
 
 Think of a recipe as a simple batch file for Windows or a shell script for Unix. It's just a text file where you place one command on each line and they are executed in order. Enter the commands exactly as you would from the interactive shell.
 
-Technically a recipe can have any file extension, but the default recommendation is `.boxr` which stands for "box recipe". Lines that start with a \# will be ignored as comments.
+Technically a recipe can have any file extension, but the default recommendation is `.boxr` which stands for "box recipe". Lines that start with a pound and whitespace characters (e.g. "# My Comments") will be ignored as comments. The pound character followed immediately by word-like characters is the mechanism for invoking [CFML functions](/usage/execution/cfml-functions).
 
 **buildSite.boxr**
 


### PR DESCRIPTION
The update makes it explicit that "#My Comments" won't work; instead "# My Comments" should be used.

Couldn't figure out the correct URL for the docs, so an existing problem remains.