### PR TITLE
resolvePath() is now available directly to commands

### DIFF
--- a/developing-for-commandbox/commands/using-parameters/README.md
+++ b/developing-for-commandbox/commands/using-parameters/README.md
@@ -16,14 +16,14 @@ package set foo=bar
 
 ## File System Paths As Parameters
 
-If your command accepts a file or folder path from the user, you'll want to resolve that path before you use it. To do this, use the `fileSystemUtil` object that is available to all commands via the BaseCommand class. The method `resolvePath()` will make the file system path canonical and absolute. This ensures you have a fully qualified path to work with even if a user might passed a folder relative to their current working directory passed something like `../../`.
+If your command accepts a file or folder path from the user, you'll want to resolve that path before you use it. To do this, use the `resolvePath()` method that is available to all commands via the BaseCommand class. (This method wraps the `resolvePath()` method of the `fileSystemUtil` object that is injected into all commands.) The method `resolvePath()` will make the file system path canonical and absolute. This ensures you have a fully qualified path to work with even if a user might passed a folder relative to their current working directory passed something like `../../`.
 
 ```javascript
 component extends="commandbox.system.BaseCommand" {
 
     function run( String directory )  {
         // This will make each directory canonical and absolute
-        arguments.directory = fileSystemUtil.resolvePath( arguments.directory );
+        arguments.directory = resolvePath( arguments.directory );
         return arguments.directory;
     }
 }


### PR DESCRIPTION
I thought it would be nice to update the documentation and example to show that `resolvePath()` is available directly to commands now. Assuming you are ok with that update, I wasn't sure if you would want to retain the info about filesystemUtil being available to all commands as well, so I left it in a parenthetical note.